### PR TITLE
Configurable gift card SKUs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+.idea

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 This is a [Hubot](https://hubot.github.com/) plugin with two functions:
 
 1. Enable you to publicly high-five someone in the chat room.
-1. Optionally send them an Amazon gift card.
+1. Optionally send them a gift card.
 
 ## Installation
 
@@ -32,7 +32,7 @@ hubot highfive @john for nailing that design
 ```
 
 Hubot will then send a message to the current room (or a configurable public room, see below) with congratulations and a nice GIF.
-If configured properly, this command will additionally trigger an Amazon.com gift card to be sent to the high-fived user:
+If configured properly, this command will additionally trigger a gift card to be sent to the high-fived user:
 
 ```
 hubot highfive @jane $25 for landing that huge account
@@ -64,6 +64,7 @@ Once you've done that, you'll need to tell the plugin some values:
 
 - The award limit (`HUBOT_HIGHFIVE_AWARD_LIMIT`) sets an upper bound on the size of gift card that can be sent. The default is $150.
 - The daily limit (`HUBOT_HIGHFIVE_DAILY_LIMIT`) sets a limit on how much any single user can give out in a day. The default is $500.
+- The gift card SKU (`HUBOT_TANGOCARD_SKU`) configures which type of gift card you want to send to your team.  You can see the complete list at https://sandbox.tangocard.com/raas/v1/rewards
 - Overriding the Tango Card root URL (`HUBOT_TANGOCARD_ROOTURL`) lets you use the sandbox API for testing (it's at https://sandbox.tangocard.com/raas/v1/). The default is the production endpoint.
 - When you sign up for the Tango Card API, they'll provide you with a username (`HUBOT_TANGOCARD_USER`) and a secret key (`HUBOT_TANGOCARD_KEY`).
 - The customer and account fields (`HUBOT_TANGOCARD_CUSTOMER` and `HUBOT_TANGOCARD_ACCOUNT`) are fairly arbitrary, and only really exist so you can track expenses through Tango Card. This plugin will use the same values for every card it orders.
@@ -97,5 +98,4 @@ This will set the following environment variables:
 ## TODO
 
 - Chat services that aren't Slack.
-- Tango Card gifts other than Amazon.com
 - Other logging services

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Once you've done that, you'll need to tell the plugin some values:
 
 - The award limit (`HUBOT_HIGHFIVE_AWARD_LIMIT`) sets an upper bound on the size of gift card that can be sent. The default is $150.
 - The daily limit (`HUBOT_HIGHFIVE_DAILY_LIMIT`) sets a limit on how much any single user can give out in a day. The default is $500.
-- The gift card SKU (`HUBOT_TANGOCARD_SKU`) configures which type of gift card you want to send to your team.  You can see the complete list at https://sandbox.tangocard.com/raas/v1/rewards
+- The gift card SKU (`HUBOT_TANGOCARD_SKU`) configures which type of gift card you want to send to your team (defaults to an Amazon card if not set.)  You can see the complete list at https://sandbox.tangocard.com/raas/v1/rewards
 - Overriding the Tango Card root URL (`HUBOT_TANGOCARD_ROOTURL`) lets you use the sandbox API for testing (it's at https://sandbox.tangocard.com/raas/v1/). The default is the production endpoint.
 - When you sign up for the Tango Card API, they'll provide you with a username (`HUBOT_TANGOCARD_USER`) and a secret key (`HUBOT_TANGOCARD_KEY`).
 - The customer and account fields (`HUBOT_TANGOCARD_CUSTOMER` and `HUBOT_TANGOCARD_ACCOUNT`) are fairly arbitrary, and only really exist so you can track expenses through Tango Card. This plugin will use the same values for every card it orders.

--- a/src/lib/api/tangocard.coffee
+++ b/src/lib/api/tangocard.coffee
@@ -22,7 +22,7 @@ class TangoApp extends BaseApiApp
             security_code: auth
         , callback
 
-    orderAmazonDotComCard: (cust, acct, campaign, amt, from, subject, to, email, message, callback) ->
+    orderGiftCard: (cust, acct, campaign, amt, from, subject, to, email, message, callback) ->
         data =
             customer: cust
             account_identifier: acct
@@ -30,7 +30,7 @@ class TangoApp extends BaseApiApp
             recipient:
                 name: to
                 email: email
-            sku: "AMZN-E-V-STD"
+            sku: process.env.HUBOT_TANGOCARD_SKU || "AMZN-E-V-STD"
             amount: amt
             reward_from: from
             reward_subject: subject

--- a/src/lib/tango.coffee
+++ b/src/lib/tango.coffee
@@ -15,7 +15,7 @@ module.exports = (robot) ->
         doOrder = ->
             # Place an order
             message = "High five for #{reason}!"
-            app.orderAmazonDotComCard cust, acct, 'High-five',
+            app.orderGiftCard cust, acct, 'High-five',
                                       Math.floor(dollars*100),
                                       from_user.real_name, 'High Five!',
                                       to_user.real_name, to_user.email,


### PR DESCRIPTION
This PR adds the ability to set a card SKU via environment variable.  If not set, it defaults to the Amazon SKU, preserving backward compatibility.
