### PR TITLE
Add optional eavesdropping behavior.

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,10 +49,11 @@ hubot highfive config
 Hubot will give you a link to the configuration page, where a form will help walk you through all the environment variables you need/want to set.
 When you're done filling out the form (and optionally submitting the credit-card information), copy the contents of the text area at the bottom, and paste them into a `heroku config` or `export` command-line, so all the values become part of Hubot's environment.
 
-The basic high-five configuration consists of just two options:
+The basic high-five configuration consists of just three options:
 
 - The chat service (`HUBOT_HIGHFIVE_EMAIL_SERVICE`) helps the plugin figure out how to find the right room to send messages to, and how to format messages properly. If this is set to `slack`, you'll also need to configure `HUBOT_SLACK_API_TOKEN`.
 - The announcement room (`HUBOT_HIGHFIVE_ROOM`)  sets the room in which high-fives are announced. If it's empty, the plugin will just spit messages out to the room it's triggered in.
+- Hubot can eavesdrop (`HUBOT_HIGHFIVE_ALLOW_EAVESDROPPING`) to notice a `highfive @user...` even when Hubot itself isn't directly asked to do the highfive.
 
 You can add some custom GIFs by specifying `HUBOT_HIGHFIVE_GIFS` to be a set of URLs separated by spaces.
 

--- a/config/config.coffee
+++ b/config/config.coffee
@@ -7,6 +7,7 @@ class MainViewModel
         @fieldnames = [
             'HUBOT_HIGHFIVE_CHAT_SERVICE',
             'HUBOT_HIGHFIVE_ROOM',
+            'HUBOT_HIGHFIVE_ALLOW_EAVESDROPPING',
             'HUBOT_HIGHFIVE_AWARD_LIMIT',
             'HUBOT_HIGHFIVE_DAILY_LIMIT',
             'HUBOT_HIGHFIVE_DOUBLE_RATE',

--- a/config/config.html
+++ b/config/config.html
@@ -20,12 +20,26 @@
     <div class="grid-form">
         <fieldset>
             <legend>Plugin Settings</legend>
+
             <div data-row-span="3">
                 <div data-field-span="1">
                     <label>Chat Service</label>
                     <select data-bind="options: services, value: HUBOT_HIGHFIVE_CHAT_SERVICE">
                     </select>
                 </div>
+                <div data-field-span="1">
+                    <label>Announcement Room</label>
+                    <input type="text" data-bind="value: HUBOT_HIGHFIVE_ROOM,
+                                                  valueUpdate: 'input'">
+                </div>
+                <div data-field-span="1">
+                    <label>Allow Eavesdropping (true/false, default false)</label>
+                    <input type="text" data-bind="value: HUBOT_HIGHFIVE_ALLOW_EAVESDROPPING,
+                                                  valueUpdate: 'input'">
+                </div>
+            </div>
+
+            <div data-row-span="4">
                 <div data-field-span="1">
                     <label>Award Limit (default 150)</label>
                     <input type="text" data-bind="value: HUBOT_HIGHFIVE_AWARD_LIMIT,
@@ -34,14 +48,6 @@
                 <div data-field-span="1">
                     <label>Daily Gifting Limit (default 500/giver/day)</label>
                     <input type="text" data-bind="value: HUBOT_HIGHFIVE_DAILY_LIMIT,
-                                                  valueUpdate: 'input'">
-                </div>
-            </div>
-
-            <div data-row-span=3>
-                <div data-field-span="1">
-                    <label>Announcement Room</label>
-                    <input type="text" data-bind="value: HUBOT_HIGHFIVE_ROOM,
                                                   valueUpdate: 'input'">
                 </div>
                 <div data-field-span="1">

--- a/src/highfive.coffee
+++ b/src/highfive.coffee
@@ -145,7 +145,7 @@ module.exports = (robot) ->
     # to a string in order to substitute in the directed form of address.
     highfiveExpr = /^(DIRECT_ADDRESS)?\s*highfive\s+(.+?)(?:\s+\$(\S+))?(?:\s+for)?\s+(.*)/.toString().split('/')[1]
     highfiveExpr = highfiveExpr.replace 'DIRECT_ADDRESS', directAddressExpr
-    highfiveRe = new RegExp highfiveExpr
+    highfiveRe = new RegExp highfiveExpr, 'i'
 
     # The main responder
     robot.hear highfiveRe, (msg) ->


### PR DESCRIPTION
Fixes issue #8.

With `HUBOT_HIGHFIVE_ALLOW_EAVESDROPPING` set to 'true', allows Hubot to "hear" highfives in addition to when it is directly addressed.
Some code and test refactoring to ensure all variations are tested.
Config UI altered to include new `HUBOT_HIGHFIVE_ALLOW_EAVESDROPPING` environment variable.
