### PR TITLE
Hack around changes to Slack user listing api

### DIFF
--- a/src/lib/slack_chat_service.coffee
+++ b/src/lib/slack_chat_service.coffee
@@ -21,6 +21,7 @@ module.exports = (robot, gifGenerator) ->
         theUser = ->
             user = (u for u in users_cache when uid in [u.name, u.id])[0]
             user.email = user.profile.email if user
+            user.real_name ?= user.profile.real_name if user
             user
 
         user = do theUser


### PR DESCRIPTION
Hi! We use and love this Hubot plugin.

We're seeing our Slack `user.listing` API calls come down missing a `real_name` on the user. This results in our Tangocard orders failing with `'Recipient Name is missing and it is not optional`. I'm guessing that Slack is gradually migrating those fields over to the `profile` property, but have found no evidence in a few minutes of quick Googling to prove that.

This PR just copies the `profile.real_name` onto the `user` object that eventually gets passed to Tangocard for ordering. I'm not sure if there's a better way to handle this, but this was the 5min fix that got our highfives flowing again.