### PR TITLE
Replace jsonip with icanhazip

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
 language: node_js
 node_js:
-  - "0.12"
+  - "6"
+  - "8"
+  - "10"

--- a/src/lib/tango.coffee
+++ b/src/lib/tango.coffee
@@ -39,9 +39,8 @@ module.exports = (robot) ->
             return doOrder() if resp.account?.available_balance >= dollars*100
 
             # Account needs more money
-            robot.http('http://jsonip.com').get() (err, res, body) ->
-                jsonip = JSON.parse body
-                app.fundAccount cust, acct, amtToFund, jsonip.ip, cc, auth, (resp) ->
-                    return doOrder() if resp.success
-                    robot.logger.info "TANGO funding response #{JSON.stringify resp}"
-                    msg.reply "(Problem funding Tango Card account: '#{resp.denial_message}'. Check the logs; you might want `highfive config`.)"
+            # Unconditionally fund the account with hardcoded IP address
+            app.fundAccount cust, acct, amtToFund, '0.0.0.0', cc, auth, (resp) ->
+                return doOrder() if resp.success
+                robot.logger.info "TANGO funding response #{JSON.stringify resp}"
+                msg.reply "(Problem funding Tango Card account: '#{resp.denial_message}'. Check the logs; you might want `highfive config`.)"

--- a/test/command_spec.coffee
+++ b/test/command_spec.coffee
@@ -62,9 +62,6 @@ prepNock = ->
                 delivered_at: moment.utc().toISOString()
                 reward:
                     number: '123'
-    nock('http://jsonip.com')
-        .get('/')
-        .reply 200, ip: '0.0.0.0'
 
 cleanup = ->
     robot.server.close()


### PR DESCRIPTION
## What

This PR replaces `jsonip.com` with http://icanhazip.com/, a free service which fulfills the same task, but does so without returning any extra data or junk solicitations.

See also: https://major.io/icanhazip-com-faq/

## Why 

We've noticed some significant issues with using the jsonip service. Requests error out or are blocked with frustrating frequency.

Fixes #13.